### PR TITLE
Add PLAYER_VS_PLAYER functionality to SDK and Controller

### DIFF
--- a/config/path-dir.ts
+++ b/config/path-dir.ts
@@ -113,6 +113,14 @@ export const PATH_SDK = {
   PLAYER_FANTASY: conNexSegment(SEGMENT.PLAYER, SEGMENT.ID, SEGMENT.FANTASY),
 
   /**
+   * The player compare directory path.
+   * @route /player/{player2Id}/vs/{player2Id}
+   * @param id - The player ID.
+   * @returns The player compare directory path.
+   */
+  PLAYER_VS_PLAYER: conNexSegment(SEGMENT.PLAYER, SEGMENT.PLAYER_1_ID, SEGMENT.VS, SEGMENT.PLAYER_2_ID),
+
+  /**
    * The draft history directory path.
    * @route /draft/history
    */
@@ -195,6 +203,12 @@ export const PATH_SDK = {
    * @route /common/all/player
    */
   COMMON_ALL_PLAYER: conNexSegment(SEGMENT.COMMON, SEGMENT.ALL, SEGMENT.PLAYER),
+
+  /**
+   * The game finder directory path.
+   * @route /game
+   */
+  GAME_FINDER: conNexSegment(SEGMENT.GAME),
 
   /**
    * The synergy playtype directory path.

--- a/config/sdk-dir.ts
+++ b/config/sdk-dir.ts
@@ -95,6 +95,16 @@ export const SDK_DIR = {
   PLAYER_FANTASY: (id: any) => conNex(GLOBAL.SDK_URL, SEGMENT.PLAYER, id, SEGMENT.FANTASY),
 
   /**
+   * Returns the player vs player directory path for the specified player IDs.
+   *
+   * {base_sdk_url}/player/{player1Id}/vs/{player2Id}
+   *
+   * @param player1Id - The first player ID.
+   * @param player2Id - The second player ID.
+   * @returns The player vs player directory path.
+   */
+  PLAYER_VS_PLAYER: (player1Id: any, player2Id: any) => conNex(GLOBAL.SDK_URL, SEGMENT.PLAYER, player1Id, SEGMENT.VS, player2Id),
+  /**
    * The league leaders directory path.
    *
    * {base_sdk_url}/leader
@@ -191,6 +201,13 @@ export const SDK_DIR = {
    * {base_sdk_url}/common/all/player
    */
   COMMON_ALL_PLAYER: conNex(GLOBAL.SDK_URL, SEGMENT.COMMON, SEGMENT.ALL, SEGMENT.PLAYER),
+
+  /**
+   * Returns the player all directory path.
+   *
+   * {base_sdk_url}/game
+   */
+  GAME_FINDER: conNex(GLOBAL.SDK_URL, SEGMENT.GAME),
 
   /**
    * Returns the synergy directory path for the specified PT.

--- a/constant/segment.ts
+++ b/constant/segment.ts
@@ -16,13 +16,17 @@ export enum SEGMENT {
   DRAFT = 'draft',
   FANTASY = 'fantasy',
   FIND = 'find',
+  FINDER = 'finder',
   FRANCHISE = 'franchise',
+  GAME = 'game',
   HISTORY = 'history',
   ID = ':id',
   INFO = 'info',
   LEADER = 'leader',
   LEAGUE = 'league',
   PLAYER = 'player',
+  PLAYER_1_ID = ':player1Id',
+  PLAYER_2_ID = ':player2Id',
   PT = 'pt',
   POINT = 'point',
   PTS = 'pts',
@@ -35,5 +39,6 @@ export enum SEGMENT {
   SYNERGY = 'synergy',
   TEAM = 'team',
   TOTAL = 'total',
-  USER = 'user'
+  USER = 'user',
+  VS = 'vs'
 }

--- a/controller/sdk-set.ts
+++ b/controller/sdk-set.ts
@@ -13,6 +13,12 @@ class SDKSetController {
     this._playerId = req.params.id
   }
 
+  /**
+   * Creates player base data.
+   *
+   * @returns A promise that resolves to the created players.
+   * @throws {TypeError} If the playerCommonData is not an array.
+   */
   public static async createPlayerBase(_req: Request, res: Response, _next: NextFunction) {
     try {
       const [playerBioResponse, playerCommonResponse] = await Promise.all([axios.get(SDK_DIR.PLAYER_ALL), axios.get(SDK_DIR.COMMON_ALL_PLAYER)])
@@ -54,6 +60,12 @@ class SDKSetController {
     }
   }
 
+  /**
+   * Creates franchise history records based on the NBA API data.
+   *
+   * @returns A promise that resolves to the created franchise history records.
+   * @throws If there is an error while creating the franchise history records.
+   */
   public static async createFranchiseHistory(_req: Request, res: Response, _next: NextFunction) {
     try {
       const franchiseCall = async () => {

--- a/controller/sdk.ts
+++ b/controller/sdk.ts
@@ -283,11 +283,49 @@ class SDKController {
     const player2Id = req.params.player2Id
 
     const season = req.query.season
+    const last_n_games = req.query.last_n_games
+    const measure_type_detailed_defense = req.query.measure_type_detailed_defense
+    const month = req.query.month
+    const opponent_team_id = req.query.opponent_team_id
+    const pace_adjust = req.query.pace_adjust
+    const per_mode_detailed = req.query.per_mode_detailed
+    const period = req.query.period
+    const plus_minus = req.query.plus_minus
+    const rank = req.query.rank
+    const season_type_playoffs = req.query.season_type_playoffs
+    const date_from_nullable = req.query.date_from_nullable
+    const date_to_nullable = req.query.date_to_nullable
+    const game_segment_nullable = req.query.game_segment_nullable
+    const league_id_nullable = req.query.league_id_nullable
+    const location_nullable = req.query.location_nullable
+    const outcome_nullable = req.query.outcome_nullable
+    const season_segment_nullable = req.query.season_segment_nullable
+    const vs_conference_nullable = req.query.vs_conference_nullable
+    const vs_division_nullable = req.query.vs_division_nullable
 
     try {
       const playerCareer = await axios.get(SDK_DIR.PLAYER_VS_PLAYER(player1Id, player2Id), {
         params: {
-          season
+          season,
+          last_n_games,
+          measure_type_detailed_defense,
+          month,
+          opponent_team_id,
+          pace_adjust,
+          per_mode_detailed,
+          period,
+          plus_minus,
+          rank,
+          season_type_playoffs,
+          date_from_nullable,
+          date_to_nullable,
+          game_segment_nullable,
+          league_id_nullable,
+          outcome_nullable,
+          location_nullable,
+          season_segment_nullable,
+          vs_conference_nullable,
+          vs_division_nullable
         }
       })
 

--- a/controller/sdk.ts
+++ b/controller/sdk.ts
@@ -278,6 +278,30 @@ class SDKController {
     }
   }
 
+  public static async getPlayerVsPlayer(req: Request, res: Response, _next: NextFunction) {
+    const player1Id = req.params.player1Id
+    const player2Id = req.params.player2Id
+
+    const season = req.query.season
+
+    try {
+      const playerCareer = await axios.get(SDK_DIR.PLAYER_VS_PLAYER(player1Id, player2Id), {
+        params: {
+          season
+        }
+      })
+
+      if (!playerCareer.data) {
+        res.status(CODE.NOT_FOUND).send(RESPONSE.NOT_FOUND(MESSAGE.NOT_FOUND))
+      } else {
+        res.status(CODE.OK).send(RESPONSE.OK(playerCareer.data))
+      }
+    } catch (error: any) {
+      goodlog.error(error)
+      res.status(CODE.INTERNAL_SERVER_ERROR).send(RESPONSE.INTERNAL_SERVER_ERROR(error.message))
+    }
+  }
+
   /**
    * Retrieves the draft history.
    *
@@ -608,6 +632,40 @@ class SDKController {
         res.status(CODE.NOT_FOUND).send(RESPONSE.NOT_FOUND(MESSAGE.NOT_FOUND))
       } else {
         res.status(CODE.OK).send(RESPONSE.OK(scoreboard.data))
+      }
+    } catch (error: any) {
+      goodlog.error(error)
+      res.status(CODE.INTERNAL_SERVER_ERROR).send(RESPONSE.INTERNAL_SERVER_ERROR(error.message))
+    }
+  }
+
+  // game
+  public static async getGameFinder(req: Request, res: Response, _next: NextFunction) {
+    try {
+      // const game_date = req.query.game_date
+      // const league_id = req.query.league_id
+      // const day_offset = req.query.day_offset
+      const player_or_team_abbreviation = req.query.player_or_team_abbreviation
+      const league_id_nullable = req.query.league_id_nullable
+      const season_nullable = req.query.season_nullable
+      const season_type_nullable = req.query.season_type_nullable
+
+      const gameFinder = await axios.get(SDK_DIR.GAME_FINDER, {
+        params: {
+          // game_date,
+          // league_id,
+          // day_offset,
+          player_or_team_abbreviation,
+          league_id_nullable,
+          season_nullable,
+          season_type_nullable
+        }
+      })
+
+      if (!gameFinder.data) {
+        res.status(CODE.NOT_FOUND).send(RESPONSE.NOT_FOUND(MESSAGE.NOT_FOUND))
+      } else {
+        res.status(CODE.OK).send(RESPONSE.OK(gameFinder.data))
       }
     } catch (error: any) {
       goodlog.error(error)

--- a/route/sdk/sdk.ts
+++ b/route/sdk/sdk.ts
@@ -15,6 +15,7 @@ router.get(PATH_SDK.PLAYER_ID, SDKController.getPlayer)
 router.get(PATH_SDK.PLAYER_AWARD, SDKController.getPlayerAward)
 router.get(PATH_SDK.PLAYER_CAREER, SDKController.getPlayerCareer)
 router.get(PATH_SDK.PLAYER_FANTASY, SDKController.getPlayerFantasyProfile)
+router.get(PATH_SDK.PLAYER_VS_PLAYER, SDKController.getPlayerVsPlayer)
 
 router.get(PATH_SDK.DRAFT_HISTORY, SDKController.getDraftHistory)
 
@@ -34,6 +35,8 @@ router.get(PATH_SDK.FRANCHISE_HISTORY, SDKController.getAllFranchiseHistory)
 router.get(PATH_SDK.ROTATION, SDKController.getRotationByGame)
 
 router.get(PATH_SDK.COMMON_ALL_PLAYER, SDKController.getAllCommonPlayer)
+
+router.get(PATH_SDK.GAME_FINDER, SDKController.getGameFinder)
 
 router.get(PATH_SDK.SYNERGY_PT, SDKController.getSynergyPlaytype)
 

--- a/sdk/sdk-server.py
+++ b/sdk/sdk-server.py
@@ -96,12 +96,49 @@ def get_player_vs_player(player_id, vs_player_id):
     """
 
     season = request.args.get('season', '2023-24')
+    last_n_games = request.args.get('last_n_games', 0)
+    measure_type_detailed_defense = request.args.get('measure_type_detailed_defense', 'Base')
+    month = request.args.get('month', 0)
+    opponent_team_id = request.args.get('opponent_team_id')
+    pace_adjust = request.args.get('pace_adjust', 'N')
+    per_mode_detailed = request.args.get('per_mode_detailed', 'Totals')
+    period = request.args.get('period', 0)
+    plus_minus = request.args.get('plus_minus', 'N')
+    rank = request.args.get('rank', 'N')
+    season_type_playoffs = request.args.get('season_type_playoffs')
+    date_from_nullable = request.args.get('date_from_nullable')
+    date_to_nullable = request.args.get('date_to_nullable')
+    game_segment_nullable = request.args.get('game_segment_nullable')
+    location_nullable = request.args.get('location_nullable')
+    outcome_nullable = request.args.get('outcome_nullable')
+    season_segment_nullable = request.args.get('season_segment_nullable')
+    vs_conference_nullable = request.args.get('vs_conference_nullable'),
+    vs_division_nullable = request.args.get('vs_division_nullable')
 
     try:
         player_vs_player = PlayerVsPlayer(
             player_id=player_id,
             vs_player_id=vs_player_id,
-            season=season
+            season=season,
+            last_n_games=last_n_games,
+            measure_type_detailed_defense=measure_type_detailed_defense,
+            month=month,
+            opponent_team_id=opponent_team_id,
+            pace_adjust=pace_adjust,
+            per_mode_detailed=per_mode_detailed,
+            period=period,
+            plus_minus=plus_minus,
+            rank=rank,
+            season_type_playoffs=season_type_playoffs,
+            date_from_nullable=date_from_nullable,
+            date_to_nullable=date_to_nullable,
+            game_segment_nullable=game_segment_nullable,
+            league_id_nullable=league_id_nullable,
+            location_nullable=location_nullable,
+            outcome_nullable=outcome_nullable,
+            season_segment_nullable=season_segment_nullable,
+            vs_conference_nullable=vs_conference_nullable,
+            vs_division_nullable=vs_division_nullable
         )
         player_vs_player_json = player_vs_player.get_normalized_json()
 

--- a/typings/model.d.ts
+++ b/typings/model.d.ts
@@ -315,17 +315,23 @@ declare interface Coach {
 declare interface Team {
   _id: Schema.Types.ObjectId
   apiCode: string
-  name: string
+  teamName: string
   city: string
   abbreviation: string
   conference: string
   division: string
   record: string
+  win: number
+  loss: number
+  winPercentage: number
+  divRank: number
+  confRank: number
+  season: Schema.Types.ObjectId
+  coach: Schema.Types.ObjectId
   stats: Schema.Types.ObjectId
-  championships: number
-  divisionTitles: number
-  conferenceTitles: number
+  franchise: Schema.Types.ObjectId
   retiredJerseys: Schema.Types.ObjectId[]
+  slug: string
   [key: string]: any
 }
 


### PR DESCRIPTION
This pull request adds the functionality to retrieve player vs player data to the SDK and Controller modules. It includes the following changes:

- Added the PLAYER_VS_PLAYER directory path to the SDK_DIR configuration object.

- Added the PLAYER_VS_PLAYER route to the SDK module.

- Updated the Franchise ownership field in the Player Module to be an array.

- Updated the properties of the Team model.

- Added the PLAYER_VS_PLAYER route to the SDK module.

- Updated the Team model properties.

- Created player base data in the SDKSetController.

- Created franchise history records based on the NBA API data in the SDKSetController.

- Added the getPlayerVsPlayer method to the SDKController to retrieve player vs player data.

- Added the getGameFinder method to the SDKController to retrieve game data.

These changes enhance the functionality of the application by providing a convenient way to access player vs player data and game data.